### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen)](https://nodejs.org/)
 [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-0.5.0-blue)](https://github.com/modelcontextprotocol)
 
+<a href="https://glama.ai/mcp/servers/@lmanchu/weather-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@lmanchu/weather-mcp-server/badge" alt="Weather Server MCP server" />
+</a>
+
 ---
 
 ## 🎯 Purpose


### PR DESCRIPTION
This PR adds a badge for the [Weather MCP Server](https://glama.ai/mcp/servers/@lmanchu/weather-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@lmanchu/weather-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@lmanchu/weather-mcp-server/badge" alt="Weather Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.